### PR TITLE
Clock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .*
 !.gitignore
+coverage.out

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,14 @@
+.PHONY: $(shell ls -d *)
+
+default:
+	@echo "Usage: make [command]"
+
+test: clock.t
+
+%.t:
+	@go test -v -race --cover ./$* && echo ""
+
+test-coverage: clock.cv
+
+%.cv:
+	@go test -coverprofile=$*/coverage.out ./$* && go tool cover -html=$*/coverage.out

--- a/README.md
+++ b/README.md
@@ -4,3 +4,20 @@ Happy Shiny Scheduler
 This is a web application intended to help improve productivity by promoting a positive, focused approach to working on tasks.
 
 More details can be found [here](https://docs.google.com/document/d/19fPz48mgMIbgPmBH03mRc4Ii2RGQ8nqGLT9ySna3WvE).
+
+## Testing
+
+The following command runs all tests in all packages:
+
+    make test
+
+If you'd like to see the test coverage information in a more visually appealing form, you can try the following instead:
+
+    make test-coverage
+
+It will save the coverage information to a file, then open a browser window showing the covered (green), uncovered (red), and uninstrumented (grey) source. You can find more information under "Viewing the results" [here](https://blog.golang.org/cover).
+
+If you only want to run tests for one package, there are commands for that as well:
+
+    make clock.t  # run tests in clock package
+    make clock.cv # show coverage information for clock package

--- a/clock/clock.go
+++ b/clock/clock.go
@@ -1,0 +1,28 @@
+package clock
+
+import "time"
+
+// Clock keeps time.
+type Clock interface {
+	// Now returns the current time according to this clock.
+	Now() time.Time
+}
+
+// StandardClock keeps time accurately.
+type StandardClock struct{}
+
+// Now returns the current time.
+func (*StandardClock) Now() time.Time {
+	return time.Now()
+}
+
+// BrokenClock has seen better days; in its mind, time is standing still.
+type BrokenClock struct {
+	// T is the time that this clock always thinks it is.
+	T time.Time
+}
+
+// Now always returns the same time.
+func (c *BrokenClock) Now() time.Time {
+	return c.T
+}

--- a/clock/clock_test.go
+++ b/clock/clock_test.go
@@ -1,0 +1,32 @@
+package clock
+
+import (
+	"testing"
+	"time"
+)
+
+func TestStandardClock(t *testing.T) {
+	c := StandardClock{}
+	before := time.Now()
+	actual := c.Now()
+	after := time.Now()
+	if !before.Before(after) {
+		t.Fatal("time is going backwards?!")
+	} else if !before.Before(actual) {
+		t.Fatalf("expected %v to be before %v; it wasn't", before, actual)
+	} else if !after.After(actual) {
+		t.Fatalf("expected %v to be after %v; it wasn't", after, actual)
+	}
+}
+
+func TestBrokenClock(t *testing.T) {
+	var zeroTime time.Time
+	testCases := []time.Time{zeroTime, time.Now()}
+	for _, tc := range testCases {
+		c := BrokenClock{T: tc}
+		actual := c.Now()
+		if !actual.Equal(tc) {
+			t.Fatalf("expected %v; got %v", tc, actual)
+		}
+	}
+}


### PR DESCRIPTION
Some of the scheduler's features depend on being able to keep time, e.g. to keep track of how much time was spent on a given task. In production, we want the timekeeping to be as accurate as possible, but for testing purposes it can be helpful to use a clock for which time is standing still, since it will have more predictable and reproducible behaviour.

To give us this flexibility, I've introduced a `Clock` interface, along with two (exceedingly) simple implementations:

- `StandardClock` - implemented using the standard `time` package; this is what we would use in production
- `BrokenClock` - initialized with a certain time (can be the zero time), which is what time it will always think it is